### PR TITLE
[#36, #38] feat: 피드 API 수정 요청 사항 반영

### DIFF
--- a/membership/src/main/java/com/devcamp/flametalk/domain/feed/controller/FeedController.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/feed/controller/FeedController.java
@@ -1,6 +1,7 @@
 package com.devcamp.flametalk.domain.feed.controller;
 
 import com.devcamp.flametalk.domain.feed.domain.FeedResponse;
+import com.devcamp.flametalk.domain.feed.dto.FeedDetailResponse;
 import com.devcamp.flametalk.domain.feed.dto.FeedsResponse;
 import com.devcamp.flametalk.domain.feed.service.FeedService;
 import com.devcamp.flametalk.global.common.CommonResponse;
@@ -53,15 +54,15 @@ public class FeedController {
    * 요청받은 id에 해당하는 피드 사진의 공개 여부를 반전시킵니다.
    *
    * @param feedId 피드 id
-   * @return 공개 여부 결과에 따른 응답 정보
+   * @return 공개 여부 결과에 따른 응답 정보와 업데이트된 피드 객체
    */
   @PutMapping("/lock/{feedId}")
-  public ResponseEntity<CommonResponse> updateLock(@PathVariable Long feedId) {
-    feedService.updateLock(feedId);
-    log.info("update feed lock {}", feedId);
-
-    CommonResponse response = new CommonResponse();
-    response.success(FeedResponse.FEED_REVERSE_LOCK_SUCCESS.getMessage());
+  public ResponseEntity<SingleDataResponse<FeedDetailResponse>> updateLock(
+      @PathVariable Long feedId) {
+    FeedDetailResponse feedDetail = feedService.updateLock(feedId);
+    log.info("update feed lock {}", feedDetail.toString());
+    SingleDataResponse<FeedDetailResponse> response = new SingleDataResponse<>();
+    response.success(FeedResponse.FEED_REVERSE_LOCK_SUCCESS.getMessage(), feedDetail);
     return ResponseEntity.ok().body(response);
   }
 

--- a/membership/src/main/java/com/devcamp/flametalk/domain/feed/dto/FeedDetailResponse.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/feed/dto/FeedDetailResponse.java
@@ -35,4 +35,21 @@ public class FeedDetailResponse {
                 feed.getIsLock(), feed.getCreatedAt(), feed.getUpdatedAt())));
     return feedDetails;
   }
+
+  /**
+   * Feed 엔티티를 통해 FeedDetailResponse 객체를 생성합니다.
+   *
+   * @param feed Feed 엔티티
+   * @return 피드 상세 정보 객체
+   */
+  public static FeedDetailResponse from(Feed feed) {
+    return new FeedDetailResponse(
+        feed.getId(),
+        feed.getImageUrl(),
+        feed.getIsBackground(),
+        feed.getIsLock(),
+        feed.getCreatedAt(),
+        feed.getUpdatedAt()
+    );
+  }
 }

--- a/membership/src/main/java/com/devcamp/flametalk/domain/feed/service/FeedService.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/feed/service/FeedService.java
@@ -61,11 +61,13 @@ public class FeedService {
    * id에 해당하는 피드 사진의 공개여부를 업데이트합니다.
    *
    * @param id 피드 id
+   * @return 업데이트된 피드 객체
    */
   @Transactional
-  public void updateLock(Long id) {
+  public FeedDetailResponse updateLock(Long id) {
     Feed feed = feedRepository.findById(id)
         .orElseThrow(() -> new EntityNotFoundException(FEED_NOT_FOUND));
     feed.reverseLock();
+    return FeedDetailResponse.from(feed);
   }
 }

--- a/membership/src/main/java/com/devcamp/flametalk/domain/profile/controller/ProfileController.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/profile/controller/ProfileController.java
@@ -73,7 +73,7 @@ public class ProfileController {
    */
   @GetMapping
   public ResponseEntity<SingleDataResponse<ProfilesResponse>> findProfile(
-      @RequestHeader String userId) {
+      @RequestHeader("USER-ID") String userId) {
     ProfilesResponse profiles = profileService.findByUserId(userId);
     SingleDataResponse<ProfilesResponse> response = new SingleDataResponse<>();
     response.success(ProfileResponse.PROFILES_SUCCESS.getMessage(), profiles);

--- a/membership/src/main/java/com/devcamp/flametalk/domain/profile/controller/ProfileController.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/profile/controller/ProfileController.java
@@ -36,7 +36,7 @@ public class ProfileController {
   private final ProfileService profileService;
 
   /**
-   * 유저 본인의 프로필을 수정합니다.
+   * 유저 본인의 프로필을 생성합니다.
    *
    * @param request 등록할 프로필 JSON 데이터
    * @return 성공한 경우 DB에 저장된 id로 uri 생성

--- a/membership/src/main/java/com/devcamp/flametalk/domain/profile/domain/ProfileRepository.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/profile/domain/ProfileRepository.java
@@ -10,4 +10,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
   List<Profile> getAllByUser(User user);
+
+  boolean existsByUserAndIsDefault(User user, boolean isDefault);
 }

--- a/membership/src/main/java/com/devcamp/flametalk/domain/profile/service/ProfileService.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/profile/service/ProfileService.java
@@ -39,7 +39,7 @@ public class ProfileService {
   public Long save(ProfileRequest request) {
     User user = userRepository.findById(request.getUserId())
         .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
-    if (profileRepository.existsByUserAndIsDefault(user, true)) {
+    if (request.isDefault() && profileRepository.existsByUserAndIsDefault(user, true)) {
       throw new EntityExistsException(ErrorCode.DEFAULT_PROFILE_EXIST);
     }
 

--- a/membership/src/main/java/com/devcamp/flametalk/domain/profile/service/ProfileService.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/profile/service/ProfileService.java
@@ -10,6 +10,7 @@ import com.devcamp.flametalk.domain.profile.dto.ProfilesResponse;
 import com.devcamp.flametalk.domain.user.domain.User;
 import com.devcamp.flametalk.domain.user.domain.UserRepository;
 import com.devcamp.flametalk.global.error.ErrorCode;
+import com.devcamp.flametalk.global.error.exception.EntityExistsException;
 import com.devcamp.flametalk.global.error.exception.EntityNotFoundException;
 import com.devcamp.flametalk.global.error.exception.ForbiddenException;
 import java.util.List;
@@ -38,6 +39,9 @@ public class ProfileService {
   public Long save(ProfileRequest request) {
     User user = userRepository.findById(request.getUserId())
         .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+    if (profileRepository.existsByUserAndIsDefault(user, true)) {
+      throw new EntityExistsException(ErrorCode.DEFAULT_PROFILE_EXIST);
+    }
 
     Profile profile = request.toProfile(user);
     profileRepository.save(profile);
@@ -72,6 +76,12 @@ public class ProfileService {
     return ProfileDetailResponse.from(profile);
   }
 
+  /**
+   * 유저가 보유한 프로필을 모두 조회합니다.
+   *
+   * @param id 유저 ID
+   * @return 유저가 보유한 모든 프로필 정보
+   */
   public ProfilesResponse findByUserId(String id) {
     User user = userRepository.findById(id)
         .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));

--- a/membership/src/main/java/com/devcamp/flametalk/domain/profile/service/ProfileService.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/profile/service/ProfileService.java
@@ -42,15 +42,19 @@ public class ProfileService {
     Profile profile = request.toProfile(user);
     profileRepository.save(profile);
 
-    saveProfileToFeed(request, profile);
+    saveImageToFeed(request, profile);
+    saveBackgroundImageToFeed(request, profile);
 
     return profile.getId();
   }
 
-  private void saveProfileToFeed(ProfileRequest request, Profile profile) {
+  private void saveImageToFeed(ProfileRequest request, Profile profile) {
     if (request.getImageUrl() != null) {
       feedRepository.save(request.imageToFeed(profile));
     }
+  }
+
+  private void saveBackgroundImageToFeed(ProfileRequest request, Profile profile) {
     if (request.getBgImageUrl() != null) {
       feedRepository.save(request.bgImageToFeed(profile));
     }
@@ -88,6 +92,14 @@ public class ProfileService {
         .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
     Profile profile = profileRepository.findById(profileId)
         .orElseThrow(() -> new EntityNotFoundException(ErrorCode.PROFILE_NOT_FOUND));
+
+    if (profile.getImageUrl() == null || !profile.getImageUrl().equals(request.getImageUrl())) {
+      saveImageToFeed(request, profile);
+    }
+    if (profile.getBgImageUrl() == null || !profile.getBgImageUrl()
+        .equals(request.getBgImageUrl())) {
+      saveBackgroundImageToFeed(request, profile);
+    }
 
     Profile requestProfile = request.toProfile(user);
     Profile updatedProfile = profile.update(requestProfile);

--- a/membership/src/main/java/com/devcamp/flametalk/global/error/ErrorCode.java
+++ b/membership/src/main/java/com/devcamp/flametalk/global/error/ErrorCode.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
   BAD_REQUEST(400, "BAD_REQUEST", "잘못된 요청입니다."),
-  DEFAULT_PROFILE_EXIST(400, "BAD_REQUEST", "기본 프로필은 하나만 생성 가능합니다"),
+  DEFAULT_PROFILE_EXIST(400, "BAD_REQUEST", "기본 프로필은 하나만 생성 가능합니다."),
 
   DELETE_FORBIDDEN_PROFILE(403, "FORBIDDEN", "삭제 권한이 없는 프로필입니다."),
   USER_NOT_FOUND(404, "NOT_FOUND", "존재하지 않는 유저입니다."),

--- a/membership/src/main/java/com/devcamp/flametalk/global/error/ErrorCode.java
+++ b/membership/src/main/java/com/devcamp/flametalk/global/error/ErrorCode.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
   BAD_REQUEST(400, "BAD_REQUEST", "잘못된 요청입니다."),
+  DEFAULT_PROFILE_EXIST(400, "BAD_REQUEST", "기본 프로필은 하나만 생성 가능합니다"),
 
   DELETE_FORBIDDEN_PROFILE(403, "FORBIDDEN", "삭제 권한이 없는 프로필입니다."),
   USER_NOT_FOUND(404, "NOT_FOUND", "존재하지 않는 유저입니다."),

--- a/membership/src/main/java/com/devcamp/flametalk/global/error/GlobalExceptionHandler.java
+++ b/membership/src/main/java/com/devcamp/flametalk/global/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.devcamp.flametalk.global.error;
 
+import com.devcamp.flametalk.global.error.exception.EntityExistsException;
 import com.devcamp.flametalk.global.error.exception.EntityNotFoundException;
 import com.devcamp.flametalk.global.error.exception.ForbiddenException;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +32,13 @@ public class GlobalExceptionHandler {
     log.error("[Missing Servlet RequestPart Exception]" + e);
     ErrorResponse response = ErrorResponse.from(ErrorCode.BAD_REQUEST);
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+  }
+
+  @ExceptionHandler(EntityExistsException.class)
+  protected ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityExistsException e) {
+    log.error("[Entity Exists Exception]" + e.getMessage());
+    ErrorResponse response = ErrorResponse.from(e.getErrorCode());
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }
 
   @ExceptionHandler(EntityNotFoundException.class)

--- a/membership/src/main/java/com/devcamp/flametalk/global/error/exception/EntityExistsException.java
+++ b/membership/src/main/java/com/devcamp/flametalk/global/error/exception/EntityExistsException.java
@@ -1,0 +1,18 @@
+package com.devcamp.flametalk.global.error.exception;
+
+import com.devcamp.flametalk.global.error.ErrorCode;
+import lombok.Getter;
+
+/**
+ * DB에 저장된 리소스가 중복되는 경우의 예외 클래스입니다.
+ */
+@Getter
+public class EntityExistsException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+
+  public EntityExistsException(ErrorCode errorCode) {
+    super(String.format("entity already exists error %s", errorCode.getMessage()));
+    this.errorCode = errorCode;
+  }
+}


### PR DESCRIPTION
It Closes #36 
* [Feed image lock update API](https://github.com/DevCamp2Flame/FlameTalk_Server/wiki/피드-사진-공개-설정) 응답 데이터에 업데이트 된 Feed 객체  정보 추가

It Closes #38 
* 프로필이 수정되는 경우 피드 업데이트 반영

기타 bug fix
* 기본 프로필은 한 개만 생성하도록 예외 처리