### PR TITLE
[#64] feat: 프로필 생성 시 sticker에 null이 저장되지 않도록 검증

### DIFF
--- a/membership/src/main/java/com/devcamp/flametalk/domain/profile/dto/ProfileRequest.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/profile/dto/ProfileRequest.java
@@ -22,6 +22,8 @@ public class ProfileRequest {
   private String imageUrl;
   private String bgImageUrl;
   private String description;
+
+  @NotNull
   private List<Sticker> sticker;
 
   @NotNull


### PR DESCRIPTION
It Closes #64 
프로필 Sticker 속성에 null이 삽입되지 않도록 검증합니다.