### PR TITLE
[#45] feat: 친구 API 구현

### DIFF
--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/controller/FriendController.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/controller/FriendController.java
@@ -41,6 +41,11 @@ public class FriendController {
       @RequestHeader("USER-ID") String userId, @RequestBody @Valid FriendCreateRequest request) {
     FriendCreateResponse friend = friendService.save(userId, request);
     SingleDataResponse<FriendCreateResponse> response = new SingleDataResponse<>();
+    if (friend == null) {
+      response.fail(Status.FRIEND_NOT_FOUND, null);
+      log.info("cannot create friend with not founded user");
+      return ResponseEntity.ok().body(response);
+    }
     response.success(Status.CREATED_FRIEND.getMessage(), friend);
     log.info("create friend relation {} ", friend.getFriendId());
     return ResponseEntity.created(URI.create("/api/membership/friend" + friend.getFriendId()))

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/controller/FriendController.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/controller/FriendController.java
@@ -2,13 +2,16 @@ package com.devcamp.flametalk.domain.friend.controller;
 
 import com.devcamp.flametalk.domain.friend.dto.FriendCreateRequest;
 import com.devcamp.flametalk.domain.friend.dto.FriendCreateResponse;
+import com.devcamp.flametalk.domain.friend.dto.FriendsCreateRequest;
 import com.devcamp.flametalk.domain.friend.service.FriendService;
+import com.devcamp.flametalk.global.common.CommonResponse;
 import com.devcamp.flametalk.global.common.SingleDataResponse;
 import com.devcamp.flametalk.global.common.Status;
 import java.net.URI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,6 +31,24 @@ import org.springframework.web.bind.annotation.RestController;
 public class FriendController {
 
   private final FriendService friendService;
+
+  /**
+   * 연락처에 해당하는 유저를 모두 나의 친구로 생성합니다.
+   *
+   * @param userId  친구 추가를 요청한 유저 id
+   * @param request 친구로 등록할 유저의 핸드폰 번호 리스트
+   * @return 생성 결과에 따른 응답 정보
+   */
+  @PostMapping("/contact")
+  public ResponseEntity<CommonResponse> saveAll(@RequestHeader("USER-ID") String userId,
+      @RequestBody @Valid FriendsCreateRequest request) {
+    friendService.saveAll(userId, request);
+    log.info("save all user contact friends");
+    CommonResponse response = new CommonResponse();
+    response.success(Status.CREATED_CONTACT_FRIENDS.getMessage());
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
 
   /**
    * 친구 관계를 생성합니다.

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/controller/FriendController.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/controller/FriendController.java
@@ -1,0 +1,49 @@
+package com.devcamp.flametalk.domain.friend.controller;
+
+import com.devcamp.flametalk.domain.friend.dto.FriendCreateRequest;
+import com.devcamp.flametalk.domain.friend.dto.FriendCreateResponse;
+import com.devcamp.flametalk.domain.friend.service.FriendService;
+import com.devcamp.flametalk.global.common.SingleDataResponse;
+import com.devcamp.flametalk.global.common.Status;
+import java.net.URI;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Membership 서버의 Friend API 처리 컨트롤러입니다.
+ */
+@Slf4j
+@CrossOrigin("*")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/membership/friend")
+public class FriendController {
+
+  private final FriendService friendService;
+
+  /**
+   * 친구 관계를 생성합니다.
+   *
+   * @param userId  친구 추가를 요청한 유저 id
+   * @param request 등록할 친구 관계의 JSON 데이터
+   * @return 생성된 친구 관계 정보
+   */
+  @PostMapping
+  public ResponseEntity<SingleDataResponse<FriendCreateResponse>> create(
+      @RequestHeader("USER-ID") String userId, @RequestBody @Valid FriendCreateRequest request) {
+    FriendCreateResponse friend = friendService.save(userId, request);
+    SingleDataResponse<FriendCreateResponse> response = new SingleDataResponse<>();
+    response.success(Status.CREATED_FRIEND.getMessage(), friend);
+    log.info("create friend relation {} ", friend.getFriendId());
+    return ResponseEntity.created(URI.create("/api/membership/friend" + friend.getFriendId()))
+        .body(response);
+  }
+}

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/controller/FriendController.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/controller/FriendController.java
@@ -2,6 +2,7 @@ package com.devcamp.flametalk.domain.friend.controller;
 
 import com.devcamp.flametalk.domain.friend.dto.FriendCreateRequest;
 import com.devcamp.flametalk.domain.friend.dto.FriendCreateResponse;
+import com.devcamp.flametalk.domain.friend.dto.FriendResponse;
 import com.devcamp.flametalk.domain.friend.dto.FriendUpdateRequest;
 import com.devcamp.flametalk.domain.friend.dto.FriendUpdateResponse;
 import com.devcamp.flametalk.domain.friend.dto.FriendsCreateRequest;
@@ -10,18 +11,21 @@ import com.devcamp.flametalk.global.common.CommonResponse;
 import com.devcamp.flametalk.global.common.SingleDataResponse;
 import com.devcamp.flametalk.global.common.Status;
 import java.net.URI;
+import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -75,6 +79,30 @@ public class FriendController {
     log.info("create friend relation {} ", friend.getFriendId());
     return ResponseEntity.created(URI.create("/api/membership/friend" + friend.getFriendId()))
         .body(response);
+  }
+
+  /**
+   * 유저가 추가한 모든 친구를 조회합니다.
+   *
+   * @param userId     유저 id
+   * @param isBirthday 생일 친구 조회 여부
+   * @param isMarked   관심 친구 조회 여부
+   * @param isHidden   숨김 친구 조회 여부
+   * @param isBlocked  차단 친구 조회 여부
+   * @return 유저의 친구 정보 리스트
+   */
+  @GetMapping
+  public ResponseEntity<SingleDataResponse<List<FriendResponse>>> findAll(
+      @RequestHeader("USER-ID") String userId, @RequestParam(required = false) boolean isBirthday,
+      @RequestParam(required = false) Boolean isMarked,
+      @RequestParam(required = false) Boolean isHidden,
+      @RequestParam(required = false) Boolean isBlocked) {
+    List<FriendResponse> friends = friendService
+        .findAll(userId, isBirthday, isMarked, isHidden, isBlocked);
+    SingleDataResponse<List<FriendResponse>> response = new SingleDataResponse<>();
+    response.success(Status.FRIENDS_SUCCESS.getMessage(), friends);
+    log.info("find friends by user id {} ", userId);
+    return ResponseEntity.ok().body(response);
   }
 
   /**

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/controller/FriendController.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/controller/FriendController.java
@@ -2,6 +2,8 @@ package com.devcamp.flametalk.domain.friend.controller;
 
 import com.devcamp.flametalk.domain.friend.dto.FriendCreateRequest;
 import com.devcamp.flametalk.domain.friend.dto.FriendCreateResponse;
+import com.devcamp.flametalk.domain.friend.dto.FriendUpdateRequest;
+import com.devcamp.flametalk.domain.friend.dto.FriendUpdateResponse;
 import com.devcamp.flametalk.domain.friend.dto.FriendsCreateRequest;
 import com.devcamp.flametalk.domain.friend.service.FriendService;
 import com.devcamp.flametalk.global.common.CommonResponse;
@@ -14,7 +16,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -71,5 +75,22 @@ public class FriendController {
     log.info("create friend relation {} ", friend.getFriendId());
     return ResponseEntity.created(URI.create("/api/membership/friend" + friend.getFriendId()))
         .body(response);
+  }
+
+  /**
+   * 친구 관계를 수정합니다.
+   *
+   * @param friendId 수정할 친구관계 id
+   * @param request  수정될 친구 관계 JSON 데이터
+   * @return 수정된 친구 관계 JSON 데이터
+   */
+  @PutMapping("/{friendId}")
+  public ResponseEntity<SingleDataResponse<FriendUpdateResponse>> update(
+      @PathVariable Long friendId, @RequestBody @Valid FriendUpdateRequest request) {
+    FriendUpdateResponse updatedFriend = friendService.update(friendId, request);
+    SingleDataResponse<FriendUpdateResponse> response = new SingleDataResponse<>();
+    response.success(Status.UPDATED_FRIEND.getMessage(), updatedFriend);
+    log.info("update friend relation {}", updatedFriend.getFriendId());
+    return ResponseEntity.ok().body(response);
   }
 }

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/Friend.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/Friend.java
@@ -75,4 +75,19 @@ public class Friend extends BaseTime {
     this.userFriend = userFriend;
     this.profile = profile;
   }
+
+  /**
+   * 친구 엔티티를 업데이트합니다.
+   *
+   * @param updatedFriend 업데이트 될 친구 관계 정보
+   * @return 업데이트된 친구 관계
+   */
+  public Friend update(Friend updatedFriend) {
+    this.preview = updatedFriend.preview;
+    this.isMarked = updatedFriend.isMarked;
+    this.isHidden = updatedFriend.isHidden;
+    this.isBlocked = updatedFriend.isBlocked;
+    this.profile = updatedFriend.profile;
+    return this;
+  }
 }

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/Friend.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/Friend.java
@@ -31,13 +31,13 @@ public class Friend extends BaseTime {
   private Preview preview;
 
   @NotNull
-  private boolean isMarked;
+  private Boolean isMarked;
 
   @NotNull
-  private boolean isHidden;
+  private Boolean isHidden;
 
   @NotNull
-  private boolean isBlocked;
+  private Boolean isBlocked;
 
   @ManyToOne
   @JoinColumn(name = "user_id")

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/Friend.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/Friend.java
@@ -11,6 +11,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -49,4 +50,29 @@ public class Friend extends BaseTime {
   @ManyToOne
   @JoinColumn(name = "assigned_profile_id")
   private Profile profile;
+
+  /**
+   * Friend 엔티티의 빌더입니다.
+   *
+   * @param id         친구 관계 id
+   * @param preview    친구에게 보여줄 유저의 프로필 프리뷰
+   * @param isMarked   관심 친구 여부
+   * @param isHidden   숨김 친구 여부
+   * @param isBlocked  차단 친구 여부
+   * @param user       친구 추가를 요청한 유저
+   * @param userFriend 추가되는 친구에 해당하는 유저
+   * @param profile    유저가 친구에게 보여줄 프로필
+   */
+  @Builder
+  public Friend(Long id, Preview preview, boolean isMarked, boolean isHidden, boolean isBlocked,
+      User user, User userFriend, Profile profile) {
+    this.id = id;
+    this.preview = preview;
+    this.isMarked = isMarked;
+    this.isHidden = isHidden;
+    this.isBlocked = isBlocked;
+    this.user = user;
+    this.userFriend = userFriend;
+    this.profile = profile;
+  }
 }

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/Friend.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/Friend.java
@@ -1,0 +1,52 @@
+package com.devcamp.flametalk.domain.friend.domain;
+
+import com.devcamp.flametalk.domain.model.BaseTime;
+import com.devcamp.flametalk.domain.profile.domain.Profile;
+import com.devcamp.flametalk.domain.user.domain.User;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Friend 엔티티 입니다.
+ */
+@Getter
+@NoArgsConstructor
+@Entity
+public class Friend extends BaseTime {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Convert(converter = PreviewConverter.class)
+  private Preview preview;
+
+  @NotNull
+  private boolean isMarked;
+
+  @NotNull
+  private boolean isHidden;
+
+  @NotNull
+  private boolean isBlocked;
+
+  @ManyToOne
+  @JoinColumn(name = "user_id")
+  private User user;
+
+  @ManyToOne
+  @JoinColumn(name = "friend_id")
+  private User userFriend;
+
+  @ManyToOne
+  @JoinColumn(name = "assigned_profile_id")
+  private Profile profile;
+}

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/FriendRepository.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/FriendRepository.java
@@ -1,6 +1,7 @@
 package com.devcamp.flametalk.domain.friend.domain;
 
 import com.devcamp.flametalk.domain.user.domain.User;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,4 +13,8 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
   Optional<Friend> findByUserAndUserFriend(User user, User friend);
 
   boolean existsByUserAndUserFriend(User user, User friend);
+
+  List<Friend> findAllByUserAndIsMarked(User user, Boolean isMarked);
+
+  List<Friend> findAllByUserAndIsBlockedAndIsHidden(User user, Boolean isBlocked, Boolean isHidden);
 }

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/FriendRepository.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/FriendRepository.java
@@ -1,5 +1,7 @@
 package com.devcamp.flametalk.domain.friend.domain;
 
+import com.devcamp.flametalk.domain.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
@@ -7,4 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
  */
 public interface FriendRepository extends JpaRepository<Friend, Long> {
 
+  Optional<Friend> findByUserAndUserFriend(User user, User friend);
+
+  boolean existsByUserAndUserFriend(User user, User friend);
 }

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/FriendRepository.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/FriendRepository.java
@@ -1,0 +1,10 @@
+package com.devcamp.flametalk.domain.friend.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Friend 엔티티의 저장소 Repository 입니다.
+ */
+public interface FriendRepository extends JpaRepository<Friend, Long> {
+
+}

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/Preview.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/Preview.java
@@ -1,5 +1,6 @@
 package com.devcamp.flametalk.domain.friend.domain;
 
+import com.devcamp.flametalk.domain.profile.domain.Profile;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,4 +16,18 @@ public class Preview {
   private Long profileId;
   private String imageUrl;
   private String description;
+
+  /**
+   * 프로필로부터 프리뷰를 생성합니다.
+   *
+   * @param profile 프로필 엔티티
+   * @return 프리뷰 객체
+   */
+  public static Preview from(Profile profile) {
+    return new Preview(
+        profile.getId(),
+        profile.getImageUrl(),
+        profile.getDescription()
+    );
+  }
 }

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/Preview.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/Preview.java
@@ -1,0 +1,18 @@
+package com.devcamp.flametalk.domain.friend.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Friend 엔티티에 JSON 형식으로 저장되는 프로필 프리뷰 객체입니다.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class Preview {
+
+  private Long profileId;
+  private String imageUrl;
+  private String description;
+}

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/PreviewConverter.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/domain/PreviewConverter.java
@@ -1,0 +1,34 @@
+package com.devcamp.flametalk.domain.friend.domain;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import javax.persistence.AttributeConverter;
+
+/**
+ * Preview 객체를 DB 테이블에 JSON 형태로 저장하기 위한 Converter 입니다.
+ */
+public class PreviewConverter implements AttributeConverter<Preview, String> {
+
+  private static final ObjectMapper objectMapper = new ObjectMapper()
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  @Override
+  public String convertToDatabaseColumn(Preview attribute) {
+    try {
+      return objectMapper.writeValueAsString(attribute);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("argument error");
+    }
+  }
+
+  @Override
+  public Preview convertToEntityAttribute(String dbData) {
+    try {
+      return objectMapper.readValue(dbData, Preview.class);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("error");
+    }
+  }
+}

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendCreateRequest.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendCreateRequest.java
@@ -1,0 +1,46 @@
+package com.devcamp.flametalk.domain.friend.dto;
+
+import com.devcamp.flametalk.domain.friend.domain.Friend;
+import com.devcamp.flametalk.domain.friend.domain.Preview;
+import com.devcamp.flametalk.domain.profile.domain.Profile;
+import com.devcamp.flametalk.domain.user.domain.User;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 친구 한명 추가 요청을 위한 클래스입니다.
+ */
+@AllArgsConstructor
+@Getter
+public class FriendCreateRequest {
+
+  @NotNull
+  private Long profileId;
+
+  @NotNull
+  @Size(min = 13, max = 13)
+  private String phoneNumber;
+
+  /**
+   * 인스턴스 정보를 Friend 엔티티로 반환하는 메소드입니다.
+   *
+   * @param user       친구를 추가하고자하는 유저
+   * @param userFriend 친구 추가 대상 유저
+   * @param profile    유저가 추가하는 친구에게 보여줄 유저의 프로필
+   * @param preview    유저가 추가하는 친구에게 보여줄 유저의 프로필의 프리뷰
+   * @return Friend 엔티티
+   */
+  public Friend toFriend(User user, User userFriend, Profile profile, Preview preview) {
+    return Friend.builder()
+        .user(user)
+        .userFriend(userFriend)
+        .profile(profile)
+        .preview(preview)
+        .isMarked(false)
+        .isHidden(false)
+        .isBlocked(false)
+        .build();
+  }
+}

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendCreateRequest.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendCreateRequest.java
@@ -8,10 +8,12 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * 친구 한명 추가 요청을 위한 클래스입니다.
  */
+@NoArgsConstructor
 @AllArgsConstructor
 @Getter
 public class FriendCreateRequest {

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendCreateResponse.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendCreateResponse.java
@@ -1,6 +1,7 @@
 package com.devcamp.flametalk.domain.friend.dto;
 
 import com.devcamp.flametalk.domain.friend.domain.Friend;
+import com.devcamp.flametalk.domain.friend.domain.Preview;
 import com.devcamp.flametalk.domain.profile.domain.Profile;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -43,13 +44,13 @@ public class FriendCreateResponse {
    * @param userFriendRelation 추가하는 친구 유저의 친구관계 Entity
    * @return 생성된 친구 관계 응답 정보
    */
-  public static FriendCreateResponse of(Friend friend, Friend userFriendRelation) {
+  public static FriendCreateResponse of(Friend friend, Preview preview) {
     return new FriendCreateResponse(
         friend.getId(),
         friend.getUserFriend().getNickname(),
-        userFriendRelation.getPreview().getProfileId(),
-        userFriendRelation.getPreview().getImageUrl(),
-        userFriendRelation.getPreview().getDescription()
+        preview.getProfileId(),
+        preview.getImageUrl(),
+        preview.getDescription()
     );
   }
 }

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendCreateResponse.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendCreateResponse.java
@@ -1,0 +1,55 @@
+package com.devcamp.flametalk.domain.friend.dto;
+
+import com.devcamp.flametalk.domain.friend.domain.Friend;
+import com.devcamp.flametalk.domain.profile.domain.Profile;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 친구 추가 응답을 위한 클래스입니다.
+ */
+@AllArgsConstructor
+@Getter
+public class FriendCreateResponse {
+
+  private Long friendId;
+  private String friendNickname;
+  private Long profileId;
+  private String imageUrl;
+  private String description;
+
+  /**
+   * 유저 혼자 친구 추가한 경우, Friend 엔티티와 Profile 엔티티로부터 응답 객체를 생성하는 정적 팩토리 메소드입니다.
+   *
+   * @param friend        친구 관계 Entity
+   * @param friendProfile 추가한 친구의 기본 프로필 Entity
+   * @return 생성된 친구 관계 응답 정보
+   */
+  public static FriendCreateResponse ofOneSide(Friend friend, Profile friendProfile) {
+    return new FriendCreateResponse(
+        friend.getId(),
+        friend.getUserFriend().getNickname(),
+        friendProfile.getId(),
+        friendProfile.getImageUrl(),
+        friendProfile.getDescription()
+    );
+  }
+
+  /**
+   * 상대방이 나를 친구로 추가하고 나도 친구로 추가한 경우, 나의 Friend 관계 정보와 친구의 Friend 관계 정보를 바탕으로 응답 객체를 생성하는 정적 팩토리
+   * 메소드입니다.
+   *
+   * @param friend             유저의 친구 관계 Entity
+   * @param userFriendRelation 추가하는 친구 유저의 친구관계 Entity
+   * @return 생성된 친구 관계 응답 정보
+   */
+  public static FriendCreateResponse of(Friend friend, Friend userFriendRelation) {
+    return new FriendCreateResponse(
+        friend.getId(),
+        friend.getUserFriend().getNickname(),
+        userFriendRelation.getPreview().getProfileId(),
+        userFriendRelation.getPreview().getImageUrl(),
+        userFriendRelation.getPreview().getDescription()
+    );
+  }
+}

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendResponse.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendResponse.java
@@ -1,0 +1,23 @@
+package com.devcamp.flametalk.domain.friend.dto;
+
+import com.devcamp.flametalk.domain.friend.domain.Preview;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 유저의 친구 정보 응답을 위한 클래스입니다.
+ */
+@AllArgsConstructor
+@Getter
+public class FriendResponse implements Comparable<FriendResponse> {
+
+  private Long friendId;
+  private String userId;
+  private String nickname;
+  private Preview preview;
+
+  @Override
+  public int compareTo(FriendResponse o) {
+    return this.nickname.compareTo(o.nickname);
+  }
+}

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendType.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendType.java
@@ -1,0 +1,39 @@
+package com.devcamp.flametalk.domain.friend.dto;
+
+import com.devcamp.flametalk.domain.friend.domain.Friend;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 응답 시 친구 관계를 명확하게 보여주는 enum 입니다.
+ */
+@AllArgsConstructor
+@Getter
+public enum FriendType {
+
+  DEFAULT(0),
+  MARKED(1),
+  HIDDEN(2),
+  BLOCKED(3);
+
+  private final int type;
+
+  /**
+   * 친구 엔티티 정보를 바탕으로 친구 관계 타입을 매칭합니다.
+   *
+   * @param friend 친구 엔티티
+   * @return 친구 타입
+   */
+  public static FriendType of(Friend friend) {
+    if (friend.isBlocked()) {
+      return BLOCKED;
+    }
+    if (friend.isHidden()) {
+      return HIDDEN;
+    }
+    if (friend.isMarked()) {
+      return MARKED;
+    }
+    return DEFAULT;
+  }
+}

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendType.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendType.java
@@ -25,13 +25,13 @@ public enum FriendType {
    * @return 친구 타입
    */
   public static FriendType of(Friend friend) {
-    if (friend.isBlocked()) {
+    if (Boolean.TRUE.equals(friend.getIsBlocked())) {
       return BLOCKED;
     }
-    if (friend.isHidden()) {
+    if (Boolean.TRUE.equals(friend.getIsHidden())) {
       return HIDDEN;
     }
-    if (friend.isMarked()) {
+    if (Boolean.TRUE.equals(friend.getIsMarked())) {
       return MARKED;
     }
     return DEFAULT;

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendUpdateRequest.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendUpdateRequest.java
@@ -1,0 +1,49 @@
+package com.devcamp.flametalk.domain.friend.dto;
+
+
+import com.devcamp.flametalk.domain.friend.domain.Friend;
+import com.devcamp.flametalk.domain.friend.domain.Preview;
+import com.devcamp.flametalk.domain.profile.domain.Profile;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 친구 관계 수정을 위한 클래스입니다.
+ */
+@AllArgsConstructor
+@Getter
+public class FriendUpdateRequest {
+
+  @NotNull
+  public Long assignedProfileId;
+
+  @NotNull
+  public boolean isMarked;
+
+  @NotNull
+  public boolean isHidden;
+
+  @NotNull
+  public boolean isBlocked;
+
+  /**
+   * 인스턴스 정보를 업데이트할 Friend 엔티티로 반환하는 메소드입니다.
+   *
+   * @param friend  기존 Friend 엔티티
+   * @param profile 친구에게 새로 할당할 프로필
+   * @return 업데이트된 Friend 엔티티
+   */
+  public Friend toFriend(Friend friend, Profile profile) {
+    return Friend.builder()
+        .id(friend.getId())
+        .preview(Preview.from(profile))
+        .isMarked(isMarked)
+        .isHidden(isHidden)
+        .isBlocked(isBlocked)
+        .user(friend.getUser())
+        .userFriend(friend.getUserFriend())
+        .profile(profile)
+        .build();
+  }
+}

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendUpdateResponse.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendUpdateResponse.java
@@ -1,0 +1,40 @@
+package com.devcamp.flametalk.domain.friend.dto;
+
+import com.devcamp.flametalk.domain.friend.domain.Friend;
+import com.devcamp.flametalk.domain.friend.domain.Preview;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+/**
+ * 친구 관계 수정 정보 응답을 위한 클래스입니다.
+ */
+@AllArgsConstructor
+@Getter
+public class FriendUpdateResponse {
+
+  public Long friendId;
+  public String userId;
+  public String nickname;
+  public Long assignedProfileId;
+  public String type;
+  public Preview preview;
+
+  /**
+   * Friend 엔티티와 Preview 객체를 통해 응답 객체를 생성하는 정적 팩토리 메소드입니다.
+   *
+   * @param friend               Friend 엔티티
+   * @param friendProfilePreview 친구 프로필에 대한 Preview 객체
+   * @return 수정된 친구관계 정보 응답 객체
+   */
+  public static FriendUpdateResponse of(Friend friend, Preview friendProfilePreview) {
+    return new FriendUpdateResponse(
+        friend.getId(),
+        friend.getUserFriend().getId(),
+        friend.getUserFriend().getNickname(),
+        friend.getProfile().getId(),
+        FriendType.of(friend).name(),
+        friendProfilePreview
+    );
+  }
+}

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendsCreateRequest.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/dto/FriendsCreateRequest.java
@@ -1,0 +1,20 @@
+package com.devcamp.flametalk.domain.friend.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 연락처 친구들 추가 요청을 위한 클래스입니다.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class FriendsCreateRequest {
+
+  @NotNull
+  private List<String> phoneNumbers = new ArrayList<>();
+}

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/service/FriendService.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/service/FriendService.java
@@ -5,6 +5,8 @@ import com.devcamp.flametalk.domain.friend.domain.FriendRepository;
 import com.devcamp.flametalk.domain.friend.domain.Preview;
 import com.devcamp.flametalk.domain.friend.dto.FriendCreateRequest;
 import com.devcamp.flametalk.domain.friend.dto.FriendCreateResponse;
+import com.devcamp.flametalk.domain.friend.dto.FriendUpdateRequest;
+import com.devcamp.flametalk.domain.friend.dto.FriendUpdateResponse;
 import com.devcamp.flametalk.domain.friend.dto.FriendsCreateRequest;
 import com.devcamp.flametalk.domain.profile.domain.Profile;
 import com.devcamp.flametalk.domain.profile.domain.ProfileRepository;
@@ -13,6 +15,7 @@ import com.devcamp.flametalk.domain.user.domain.UserRepository;
 import com.devcamp.flametalk.global.error.ErrorCode;
 import com.devcamp.flametalk.global.error.exception.EntityExistsException;
 import com.devcamp.flametalk.global.error.exception.EntityNotFoundException;
+import com.devcamp.flametalk.global.error.exception.ForbiddenException;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +40,7 @@ public class FriendService {
    * @param userId  친구를 추가하는 유저의 id
    * @param request 친구로 등록할 유저의 핸드폰 번호 리스트
    */
+  @Transactional
   public void saveAll(String userId, FriendsCreateRequest request) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
@@ -100,5 +104,41 @@ public class FriendService {
     }
 
     return FriendCreateResponse.of(friend, userFriendRelation);
+  }
+
+  /**
+   * DB에 저장된 친구 관계 정보를 업데이트합니다.
+   *
+   * @param friendId 업데이트할 친구 관계 id
+   * @param request  업데이트할 친구 관계 데이터
+   * @return 업데이트된 친구 관계 정보
+   */
+  @Transactional
+  public FriendUpdateResponse update(Long friendId, FriendUpdateRequest request) {
+    Friend friend = friendRepository.findById(friendId)
+        .orElseThrow(() -> new EntityNotFoundException(ErrorCode.FRIEND_NOT_FOUND));
+    Profile profile = profileRepository.findById(request.getAssignedProfileId())
+        .orElseThrow(() -> new EntityNotFoundException(ErrorCode.PROFILE_NOT_FOUND));
+    if (!profile.getUser().getId().equals(friend.getUser().getId())) {
+      throw new ForbiddenException(ErrorCode.FORBIDDEN_PROFILE);
+    }
+
+    Friend requestFriend = request.toFriend(friend, profile);
+    Friend updatedFriend = friend.update(requestFriend);
+    return FriendUpdateResponse.of(updatedFriend, getFriendProfile(friend));
+  }
+
+  private Preview getFriendProfile(Friend friend) {
+    User user = friend.getUser();
+    User userFriend = friend.getUserFriend();
+    Friend userFriendRelation = friendRepository.findByUserAndUserFriend(userFriend, user)
+        .orElse(null);
+
+    if (userFriendRelation == null) {
+      Profile friendDefaultProfile = profileRepository.findByUserAndIsDefault(userFriend, true)
+          .orElseThrow(() -> new EntityNotFoundException(ErrorCode.DEFAULT_PROFILE_NOT_FOUND));
+      return Preview.from(friendDefaultProfile);
+    }
+    return userFriendRelation.getPreview();
   }
 }

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/service/FriendService.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/service/FriendService.java
@@ -98,17 +98,7 @@ public class FriendService {
     Friend friend = request
         .toFriend(user, userFriend, assignedProfile, Preview.from(assignedProfile));
     friendRepository.save(friend);
-
-    Friend userFriendRelation = friendRepository
-        .findByUserAndUserFriend(userFriend, user).orElse(null);
-
-    if (userFriendRelation == null) {
-      Profile friendDefaultProfile = profileRepository.findByUserAndIsDefault(userFriend, true)
-          .orElseThrow(() -> new EntityNotFoundException(ErrorCode.DEFAULT_PROFILE_NOT_FOUND));
-      return FriendCreateResponse.ofOneSide(friend, friendDefaultProfile);
-    }
-
-    return FriendCreateResponse.of(friend, userFriendRelation);
+    return FriendCreateResponse.of(friend, getFriendProfile(friend));
   }
 
   /**

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/service/FriendService.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/service/FriendService.java
@@ -1,0 +1,64 @@
+package com.devcamp.flametalk.domain.friend.service;
+
+import com.devcamp.flametalk.domain.friend.domain.Friend;
+import com.devcamp.flametalk.domain.friend.domain.FriendRepository;
+import com.devcamp.flametalk.domain.friend.domain.Preview;
+import com.devcamp.flametalk.domain.friend.dto.FriendCreateRequest;
+import com.devcamp.flametalk.domain.friend.dto.FriendCreateResponse;
+import com.devcamp.flametalk.domain.profile.domain.Profile;
+import com.devcamp.flametalk.domain.profile.domain.ProfileRepository;
+import com.devcamp.flametalk.domain.user.domain.User;
+import com.devcamp.flametalk.domain.user.domain.UserRepository;
+import com.devcamp.flametalk.global.error.ErrorCode;
+import com.devcamp.flametalk.global.error.exception.EntityExistsException;
+import com.devcamp.flametalk.global.error.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Friend API 로직을 관리하는 Service 입니다.
+ */
+@RequiredArgsConstructor
+@Service
+public class FriendService {
+
+  private final FriendRepository friendRepository;
+  private final UserRepository userRepository;
+  private final ProfileRepository profileRepository;
+
+  /**
+   * 친구 관계를 DB에 생성합니다.
+   *
+   * @param userId  친구를 추가하는 유저의 id
+   * @param request 추가할 친구 요청 정보
+   * @return 추가된 친구 관계와 친구 프로필 정보
+   */
+  @Transactional
+  public FriendCreateResponse save(String userId, FriendCreateRequest request) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+    User userFriend = userRepository.findByPhoneNumber(request.getPhoneNumber())
+        .orElseThrow(() -> new EntityNotFoundException(ErrorCode.PHONE_NUMBER_NOT_FOUND));
+    Profile assignedProfile = profileRepository.findById(request.getProfileId())
+        .orElseThrow(() -> new EntityNotFoundException(ErrorCode.PROFILE_NOT_FOUND));
+    if (friendRepository.existsByUserAndUserFriend(user, userFriend)) {
+      throw new EntityExistsException(ErrorCode.FRIEND_EXIST);
+    }
+
+    Friend friend = request
+        .toFriend(user, userFriend, assignedProfile, Preview.from(assignedProfile));
+    friendRepository.save(friend);
+
+    Friend userFriendRelation = friendRepository
+        .findByUserAndUserFriend(userFriend, user).orElse(null);
+
+    if (userFriendRelation == null) {
+      Profile friendDefaultProfile = profileRepository.findByUserAndIsDefault(userFriend, true)
+          .orElseThrow(() -> new EntityNotFoundException(ErrorCode.DEFAULT_PROFILE_NOT_FOUND));
+      return FriendCreateResponse.ofOneSide(friend, friendDefaultProfile);
+    }
+
+    return FriendCreateResponse.of(friend, userFriendRelation);
+  }
+}

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/service/FriendService.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/service/FriendService.java
@@ -38,8 +38,14 @@ public class FriendService {
   public FriendCreateResponse save(String userId, FriendCreateRequest request) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+    // TODO: refactor
     User userFriend = userRepository.findByPhoneNumber(request.getPhoneNumber())
-        .orElseThrow(() -> new EntityNotFoundException(ErrorCode.PHONE_NUMBER_NOT_FOUND));
+        .orElse(null);
+    if (userFriend == null) {
+      return null;
+    }
+
     Profile assignedProfile = profileRepository.findById(request.getProfileId())
         .orElseThrow(() -> new EntityNotFoundException(ErrorCode.PROFILE_NOT_FOUND));
     if (friendRepository.existsByUserAndUserFriend(user, userFriend)) {

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/service/FriendService.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/service/FriendService.java
@@ -5,6 +5,7 @@ import com.devcamp.flametalk.domain.friend.domain.FriendRepository;
 import com.devcamp.flametalk.domain.friend.domain.Preview;
 import com.devcamp.flametalk.domain.friend.dto.FriendCreateRequest;
 import com.devcamp.flametalk.domain.friend.dto.FriendCreateResponse;
+import com.devcamp.flametalk.domain.friend.dto.FriendsCreateRequest;
 import com.devcamp.flametalk.domain.profile.domain.Profile;
 import com.devcamp.flametalk.domain.profile.domain.ProfileRepository;
 import com.devcamp.flametalk.domain.user.domain.User;
@@ -12,6 +13,8 @@ import com.devcamp.flametalk.domain.user.domain.UserRepository;
 import com.devcamp.flametalk.global.error.ErrorCode;
 import com.devcamp.flametalk.global.error.exception.EntityExistsException;
 import com.devcamp.flametalk.global.error.exception.EntityNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +29,37 @@ public class FriendService {
   private final FriendRepository friendRepository;
   private final UserRepository userRepository;
   private final ProfileRepository profileRepository;
+
+  /**
+   * 친구 관계를 모두 DB에 생성합니다. 생성된 모든 친구들에게 나의 기본 프로필을 보여줍니다. 핸드폰 번호가 등록되지 않은 유저나 이미 친구로 등록된 유저는 친구로 생성하지
+   * 않습니다.
+   *
+   * @param userId  친구를 추가하는 유저의 id
+   * @param request 친구로 등록할 유저의 핸드폰 번호 리스트
+   */
+  public void saveAll(String userId, FriendsCreateRequest request) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+    Profile userDefaultProfile = profileRepository.findByUserAndIsDefault(user, true)
+        .orElseThrow(() -> new EntityNotFoundException(ErrorCode.DEFAULT_PROFILE_NOT_FOUND));
+    Preview userDefaultProfilePreview = Preview.from(userDefaultProfile);
+
+    List<Friend> friends = new ArrayList<>();
+    request.getPhoneNumbers().forEach(phoneNumber -> {
+      User friendUser = userRepository.findByPhoneNumber(phoneNumber).orElse(null);
+      if (friendUser == null || friendRepository.existsByUserAndUserFriend(user, friendUser)) {
+        return;
+      }
+
+      FriendCreateRequest friendCreateRequest = new FriendCreateRequest(userDefaultProfile.getId(),
+          phoneNumber);
+      Friend friend = friendCreateRequest
+          .toFriend(user, friendUser, userDefaultProfile, userDefaultProfilePreview);
+      friends.add(friend);
+    });
+
+    friendRepository.saveAll(friends);
+  }
 
   /**
    * 친구 관계를 DB에 생성합니다.

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/service/FriendService.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/service/FriendService.java
@@ -119,7 +119,7 @@ public class FriendService {
    * @param isMarked   관심 친구 조회 여부
    * @param isHidden   숨김 친구 조회 여부
    * @param isBlocked  차단 친구 조회 여부
-   * @return
+   * @return 조회된 친구 정보 리스트
    */
   public List<FriendResponse> findAll(String userId, Boolean isBirthday, Boolean isMarked,
       Boolean isHidden, Boolean isBlocked) {

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/service/FriendService.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/service/FriendService.java
@@ -85,14 +85,18 @@ public class FriendService {
     // TODO: refactor
     User userFriend = userRepository.findByPhoneNumber(request.getPhoneNumber())
         .orElse(null);
+
     if (userFriend == null) {
       return null;
+    }
+    if (friendRepository.existsByUserAndUserFriend(user, userFriend)) {
+      throw new EntityExistsException(ErrorCode.FRIEND_EXIST);
     }
 
     Profile assignedProfile = profileRepository.findById(request.getProfileId())
         .orElseThrow(() -> new EntityNotFoundException(ErrorCode.PROFILE_NOT_FOUND));
-    if (friendRepository.existsByUserAndUserFriend(user, userFriend)) {
-      throw new EntityExistsException(ErrorCode.FRIEND_EXIST);
+    if (!assignedProfile.getUser().getId().equals(userId)) {
+      throw new ForbiddenException(ErrorCode.FORBIDDEN_PROFILE);
     }
 
     Friend friend = request

--- a/membership/src/main/java/com/devcamp/flametalk/domain/friend/service/FriendService.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/friend/service/FriendService.java
@@ -82,14 +82,11 @@ public class FriendService {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
 
-    // TODO: refactor
-    User userFriend = userRepository.findByPhoneNumber(request.getPhoneNumber())
-        .orElse(null);
-
-    if (userFriend == null) {
+    Optional<User> userFriend = userRepository.findByPhoneNumber(request.getPhoneNumber());
+    if (userFriend.isEmpty()) {
       return null;
     }
-    if (friendRepository.existsByUserAndUserFriend(user, userFriend)) {
+    if (friendRepository.existsByUserAndUserFriend(user, userFriend.get())) {
       throw new EntityExistsException(ErrorCode.FRIEND_EXIST);
     }
 
@@ -100,7 +97,7 @@ public class FriendService {
     }
 
     Friend friend = request
-        .toFriend(user, userFriend, assignedProfile, Preview.from(assignedProfile));
+        .toFriend(user, userFriend.get(), assignedProfile, Preview.from(assignedProfile));
     friendRepository.save(friend);
     return FriendCreateResponse.of(friend, getFriendProfile(friend));
   }

--- a/membership/src/main/java/com/devcamp/flametalk/domain/profile/domain/Profile.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/profile/domain/Profile.java
@@ -1,6 +1,7 @@
 package com.devcamp.flametalk.domain.profile.domain;
 
 import com.devcamp.flametalk.domain.feed.domain.Feed;
+import com.devcamp.flametalk.domain.friend.domain.Friend;
 import com.devcamp.flametalk.domain.model.BaseTime;
 import com.devcamp.flametalk.domain.user.domain.User;
 import java.util.ArrayList;
@@ -50,6 +51,9 @@ public class Profile extends BaseTime {
 
   @OneToMany(mappedBy = "profile")
   private List<Feed> feeds = new ArrayList<>();
+
+  @OneToMany(mappedBy = "profile")
+  private List<Friend> friends;
 
   /**
    * Profile 엔티티의 빌더입니다.

--- a/membership/src/main/java/com/devcamp/flametalk/domain/profile/domain/ProfileRepository.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/profile/domain/ProfileRepository.java
@@ -2,6 +2,7 @@ package com.devcamp.flametalk.domain.profile.domain;
 
 import com.devcamp.flametalk.domain.user.domain.User;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
@@ -12,4 +13,6 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
   List<Profile> getAllByUser(User user);
 
   boolean existsByUserAndIsDefault(User user, boolean isDefault);
+
+  Optional<Profile> findByUserAndIsDefault(User user, boolean isDefault);
 }

--- a/membership/src/main/java/com/devcamp/flametalk/domain/user/domain/User.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.devcamp.flametalk.domain.user.domain;
 
+import com.devcamp.flametalk.domain.friend.domain.Friend;
 import com.devcamp.flametalk.domain.openprofile.domain.OpenProfile;
 import com.devcamp.flametalk.domain.profile.domain.Profile;
 import java.util.ArrayList;
@@ -53,4 +54,10 @@ public class User {
 
   @OneToMany(mappedBy = "openProfileUser")
   private List<OpenProfile> openProfiles = new ArrayList<>();
+
+  @OneToMany(mappedBy = "user")
+  private List<Friend> users = new ArrayList<>();
+
+  @OneToMany(mappedBy = "user")
+  private List<Friend> friends = new ArrayList<>();
 }

--- a/membership/src/main/java/com/devcamp/flametalk/domain/user/domain/UserRepository.java
+++ b/membership/src/main/java/com/devcamp/flametalk/domain/user/domain/UserRepository.java
@@ -1,5 +1,6 @@
 package com.devcamp.flametalk.domain.user.domain;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
@@ -7,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
  */
 public interface UserRepository extends JpaRepository<User, String> {
 
+  Optional<User> findByPhoneNumber(String phoneNumber);
 }

--- a/membership/src/main/java/com/devcamp/flametalk/global/common/CommonResponse.java
+++ b/membership/src/main/java/com/devcamp/flametalk/global/common/CommonResponse.java
@@ -25,4 +25,9 @@ public class CommonResponse {
     this.status = HttpStatus.OK.value();
     this.message = message;
   }
+
+  public void fail(int status, String message) {
+    this.status = status;
+    this.message = message;
+  }
 }

--- a/membership/src/main/java/com/devcamp/flametalk/global/common/SingleDataResponse.java
+++ b/membership/src/main/java/com/devcamp/flametalk/global/common/SingleDataResponse.java
@@ -24,4 +24,9 @@ public class SingleDataResponse<T> extends CommonResponse {
     this.success(message);
     this.data = data;
   }
+
+  public void fail(Status status, T data) {
+    this.fail(status.getCode(), status.getMessage());
+    this.data = data;
+  }
 }

--- a/membership/src/main/java/com/devcamp/flametalk/global/common/Status.java
+++ b/membership/src/main/java/com/devcamp/flametalk/global/common/Status.java
@@ -1,0 +1,20 @@
+package com.devcamp.flametalk.global.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 공통 응답 결과의 코드와 메세지에 대한 Enum 입니다.
+ */
+@AllArgsConstructor
+@Getter
+public enum Status {
+
+  // 200 OK : 성공
+
+  // 201 CREATED : 새로운 리소스 생성
+  CREATED_FRIEND(201, "친구 추가 성공");
+
+  private final int code;
+  private final String message;
+}

--- a/membership/src/main/java/com/devcamp/flametalk/global/common/Status.java
+++ b/membership/src/main/java/com/devcamp/flametalk/global/common/Status.java
@@ -13,6 +13,7 @@ public enum Status {
   // 200 OK : 성공
   // 201 CREATED : 새로운 리소스 생성
   CREATED_FRIEND(201, "친구 추가 성공"),
+  CREATED_CONTACT_FRIENDS(201, "연락처 전체 친구 추가 성공"),
 
   // FAIL
   FRIEND_NOT_FOUND(404, "존재하지 않는 유저는 친구로 추가할 수 없습니다.");

--- a/membership/src/main/java/com/devcamp/flametalk/global/common/Status.java
+++ b/membership/src/main/java/com/devcamp/flametalk/global/common/Status.java
@@ -11,9 +11,11 @@ import lombok.Getter;
 public enum Status {
 
   // 200 OK : 성공
-
   // 201 CREATED : 새로운 리소스 생성
-  CREATED_FRIEND(201, "친구 추가 성공");
+  CREATED_FRIEND(201, "친구 추가 성공"),
+
+  // FAIL
+  FRIEND_NOT_FOUND(404, "존재하지 않는 유저는 친구로 추가할 수 없습니다.");
 
   private final int code;
   private final String message;

--- a/membership/src/main/java/com/devcamp/flametalk/global/common/Status.java
+++ b/membership/src/main/java/com/devcamp/flametalk/global/common/Status.java
@@ -11,6 +11,8 @@ import lombok.Getter;
 public enum Status {
 
   // 200 OK : 성공
+  UPDATED_FRIEND(200, "친구 관계 수정 성공"),
+
   // 201 CREATED : 새로운 리소스 생성
   CREATED_FRIEND(201, "친구 추가 성공"),
   CREATED_CONTACT_FRIENDS(201, "연락처 전체 친구 추가 성공"),

--- a/membership/src/main/java/com/devcamp/flametalk/global/common/Status.java
+++ b/membership/src/main/java/com/devcamp/flametalk/global/common/Status.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 public enum Status {
 
   // 200 OK : 성공
+  FRIENDS_SUCCESS(200, "친구 리스트 조회 성공"),
   UPDATED_FRIEND(200, "친구 관계 수정 성공"),
 
   // 201 CREATED : 새로운 리소스 생성

--- a/membership/src/main/java/com/devcamp/flametalk/global/error/ErrorCode.java
+++ b/membership/src/main/java/com/devcamp/flametalk/global/error/ErrorCode.java
@@ -11,10 +11,13 @@ import lombok.Getter;
 public enum ErrorCode {
   BAD_REQUEST(400, "BAD_REQUEST", "잘못된 요청입니다."),
   DEFAULT_PROFILE_EXIST(400, "BAD_REQUEST", "기본 프로필은 하나만 생성 가능합니다."),
+  FRIEND_EXIST(400, "BAD_REQUEST", "이미 추가된 친구입니다."),
 
   DELETE_FORBIDDEN_PROFILE(403, "FORBIDDEN", "삭제 권한이 없는 프로필입니다."),
   USER_NOT_FOUND(404, "NOT_FOUND", "존재하지 않는 유저입니다."),
+  PHONE_NUMBER_NOT_FOUND(404, "NOT_FOUND", "존재하지 않는 전화번호입니다."),
   PROFILE_NOT_FOUND(404, "NOT_FOUND", "존재하지 않는 프로필입니다."),
+  DEFAULT_PROFILE_NOT_FOUND(404, "NOT_FOUND", "유저의 기본 프로필이 존재하지 않습니다."),
   FEED_NOT_FOUND(404, "NOT_FOUND", "존재하지 않는 피드입니다."),
   OPEN_PROFILE_NOT_FOUND(404, "NOT_FOUND", "존재하지 않는 오픈 프로필입니다."),
 

--- a/membership/src/main/java/com/devcamp/flametalk/global/error/ErrorCode.java
+++ b/membership/src/main/java/com/devcamp/flametalk/global/error/ErrorCode.java
@@ -14,12 +14,15 @@ public enum ErrorCode {
   FRIEND_EXIST(400, "BAD_REQUEST", "이미 추가된 친구입니다."),
 
   DELETE_FORBIDDEN_PROFILE(403, "FORBIDDEN", "삭제 권한이 없는 프로필입니다."),
+  FORBIDDEN_PROFILE(403, "FORBIDDEN", "유저에게 접근 권한이 없는 프로필입니다."),
+
   USER_NOT_FOUND(404, "NOT_FOUND", "존재하지 않는 유저입니다."),
   PHONE_NUMBER_NOT_FOUND(404, "NOT_FOUND", "존재하지 않는 전화번호입니다."),
   PROFILE_NOT_FOUND(404, "NOT_FOUND", "존재하지 않는 프로필입니다."),
   DEFAULT_PROFILE_NOT_FOUND(404, "NOT_FOUND", "유저의 기본 프로필이 존재하지 않습니다."),
   FEED_NOT_FOUND(404, "NOT_FOUND", "존재하지 않는 피드입니다."),
   OPEN_PROFILE_NOT_FOUND(404, "NOT_FOUND", "존재하지 않는 오픈 프로필입니다."),
+  FRIEND_NOT_FOUND(404, "NOT_FOUND", "존재하지 않는 친구 관계입니다."),
 
   INTERNAL_SERVER_ERROR(500, "SERVER_ERROR", "서버에서 오류가 발생하였습니다.");
 


### PR DESCRIPTION
It Closes #45 
@paksuua 드디어.. 친구 API 구현하였습니다!!!! 🚀🎉🥳🚀🎉🥳
클라이언트 통신 성공하면 `develop` 브랜치로 바로 머지할게요! 😆😆

- 연락처 리스트로 친구 생성
- 특정 연락처로 친구 생성
- 유저 친구 리스트 조회
- 유저의 특정 친구 관계 수정