### PR TITLE
[#57] feat: 10MB 초과되는 파일 생성 시 오류 처리

### DIFF
--- a/file/src/main/java/com/devcamp/flametalk/domain/FileResponseMessage.java
+++ b/file/src/main/java/com/devcamp/flametalk/domain/FileResponseMessage.java
@@ -11,7 +11,9 @@ import lombok.Getter;
 public enum FileResponseMessage {
   FILE_CREATE_SUCCESS("파일 생성 성공"),
   FILE_DELETE_SUCCESS("파일 삭제 성공"),
-  FILE_DETAIL_SUCCESS("파일 조회 성공");
+  FILE_DETAIL_SUCCESS("파일 조회 성공"),
+
+  FILE_CAPACITY_FAIL("파일 용량 초과");
 
   private final String message;
 }

--- a/file/src/main/java/com/devcamp/flametalk/dto/CommonResponse.java
+++ b/file/src/main/java/com/devcamp/flametalk/dto/CommonResponse.java
@@ -16,4 +16,9 @@ public class CommonResponse {
     this.status = HttpStatus.OK.value();
     this.message = message;
   }
+
+  public void fail(int status, String message) {
+    this.status = status;
+    this.message = message;
+  }
 }

--- a/file/src/main/java/com/devcamp/flametalk/error/GlobalExceptionHandler.java
+++ b/file/src/main/java/com/devcamp/flametalk/error/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.devcamp.flametalk.error;
 
 import com.devcamp.flametalk.domain.FileResponseMessage;
 import com.devcamp.flametalk.dto.CommonResponse;
+import com.devcamp.flametalk.dto.FileDetailResponse;
+import com.devcamp.flametalk.dto.SingleDataResponse;
 import com.devcamp.flametalk.error.exception.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -39,7 +41,7 @@ public class GlobalExceptionHandler {
   protected ResponseEntity<CommonResponse> handleMaxUploadSizeExceededException(
       MaxUploadSizeExceededException e) {
     log.error("[Max Upload Size Exceeded Exception]" + e);
-    CommonResponse response = new CommonResponse();
+    SingleDataResponse<FileDetailResponse> response = new SingleDataResponse<>(null);
     response
         .fail(HttpStatus.BAD_REQUEST.value(), FileResponseMessage.FILE_CAPACITY_FAIL.getMessage());
     return ResponseEntity.status(HttpStatus.OK).body(response);

--- a/file/src/main/java/com/devcamp/flametalk/error/GlobalExceptionHandler.java
+++ b/file/src/main/java/com/devcamp/flametalk/error/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.devcamp.flametalk.error;
 
+import com.devcamp.flametalk.domain.FileResponseMessage;
+import com.devcamp.flametalk.dto.CommonResponse;
 import com.devcamp.flametalk.error.exception.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -7,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 /**
@@ -30,6 +33,16 @@ public class GlobalExceptionHandler {
     log.error("[Missing Servlet RequestPart Exception]" + e);
     ErrorResponse response = ErrorResponse.from(ErrorCode.BAD_REQUEST);
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+  }
+
+  @ExceptionHandler(MaxUploadSizeExceededException.class)
+  protected ResponseEntity<CommonResponse> handleMaxUploadSizeExceededException(
+      MaxUploadSizeExceededException e) {
+    log.error("[Max Upload Size Exceeded Exception]" + e);
+    CommonResponse response = new CommonResponse();
+    response
+        .fail(HttpStatus.BAD_REQUEST.value(), FileResponseMessage.FILE_CAPACITY_FAIL.getMessage());
+    return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 
   @ExceptionHandler(EntityNotFoundException.class)

--- a/file/src/main/resources/application.yml
+++ b/file/src/main/resources/application.yml
@@ -14,6 +14,10 @@ spring:
     url: jdbc:mysql://localhost:3306/flametalk_db?serverTimezone=UTC&characterEncoding=UTF-8
     username: flame
     password: flame123!@#
+  servlet:
+    multipart:
+      maxFileSize: 10MB
+      maxRequestSize: 10MB
 
 eureka:
   instance:


### PR DESCRIPTION
It Closes #57 

### 오류 발생 시 format
```json
{
    "status": 400,
    "message": "파일 용량 초과",
    "data": null
}
```
